### PR TITLE
Update shebang to work with virtualenv

### DIFF
--- a/cdx-index-client.py
+++ b/cdx-index-client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from argparse import ArgumentParser
 from Queue import Empty


### PR DESCRIPTION
As discussed [here](https://mail.python.org/pipermail/tutor/2007-June/054816.html) `#!/usr/bin/env python` is a preferable option. 
Otherwise despite having `pip install -r requirments.txt` under virtualenv it might happen

```
Traceback (most recent call last):
  File "./cdx-index-client.py", line 7, in <module>
    import requests
ImportError: No module named requests
```
